### PR TITLE
Added media directory option

### DIFF
--- a/src/documorph/DocumentModel.cs
+++ b/src/documorph/DocumentModel.cs
@@ -6,8 +6,8 @@ public sealed class DocumentModel(IEnumerable<MediaModel> media, IEnumerable<IDo
 {
     public IEnumerable<MediaModel> Media { get; private set; } = media;
     public IEnumerable<IDocumentChildren> Children { get; private set; } = children;
-    
-    public static DocumentModel FromDocument(WordprocessingDocument document)
+
+    public static DocumentModel FromDocument(WordprocessingDocument document, string mediaOutputRelativePath)
     {
         var body = document?.MainDocumentPart?.Document.Body;
         var numberingDefinitionsPart = document?.MainDocumentPart?.NumberingDefinitionsPart;
@@ -26,7 +26,8 @@ public sealed class DocumentModel(IEnumerable<MediaModel> media, IEnumerable<IDo
                          .RelationshipId
                      let image = part.OpenXmlPart as ImagePart
                      let fileName = image.Uri.ToString()[(image.Uri.ToString().LastIndexOf('/') + 1)..]
-                     select new MediaModel(blip?.Embed?.Value ?? string.Empty, fileName, image.ContentType, GetUniqueFileName(fileName), GetBytesFromStream(image.GetStream()))).ToList();
+                     select new MediaModel(blip?.Embed?.Value ?? string.Empty, fileName, image.ContentType,
+                        Path.Combine(mediaOutputRelativePath, GetUniqueFileName(fileName)), GetBytesFromStream(image.GetStream()))).ToList();
 
         foreach (var element in body?.ChildElements ?? new())
         {
@@ -56,6 +57,6 @@ public sealed class DocumentModel(IEnumerable<MediaModel> media, IEnumerable<IDo
     private static string GetUniqueFileName(string fileName)
     {
         var extension = Path.GetExtension(fileName);
-        return $"{Guid.NewGuid()}{extension}"; 
+        return $"{Guid.NewGuid()}{extension}";
     }
 }

--- a/src/documorph/DocxToMarkdownProcessor.cs
+++ b/src/documorph/DocxToMarkdownProcessor.cs
@@ -8,14 +8,14 @@ namespace documorph;
 /// <param name="inputFile">The .docx file to be converted</param>
 /// <exception cref="FileNotFoundException">Thrown when the input file does not exist</exception>
 /// <exception cref="InvalidDataException">Thrown when the input file is not a valid .docx file</exception>
-public sealed class DocxToMarkdownProcessor(string inputFile)
+public sealed class DocxToMarkdownProcessor(string inputFile, string mediaOutputRelativePath)
 {
     public (string Result, IEnumerable<MediaModel> Media) Process()
     {
         using var wordPackage = Package.Open(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read);
         using var wordDocument = WordprocessingDocument.Open(wordPackage);
 
-        var model = DocumentModel.FromDocument(wordDocument);
+        var model = DocumentModel.FromDocument(wordDocument, mediaOutputRelativePath);
         var result = new StringBuilder();
 
         var children = model.Children.Select((x, i) => (Element: x, Index: i)).ToList();

--- a/test/documorph.tests/DocxToMarkdownTests.cs
+++ b/test/documorph.tests/DocxToMarkdownTests.cs
@@ -46,7 +46,7 @@ Another paragraph.
 
 > This is a quote3
 
-![A screenshot of a computer  Description automatically generated](image1.png)
+![A screenshot of a computer  Description automatically generated](./image1.png)
 
 
 
@@ -58,7 +58,7 @@ After a break
     [Fact]
     public void ValidDocxReturnsValidMarkdown()
     {
-        var converter = new DocxToMarkdownProcessor("test_data/docconverter.docx");
+        var converter = new DocxToMarkdownProcessor("test_data/docconverter.docx", ".");
         var (result, media) = converter.Process();
 
         // code files are saved using windows format.
@@ -75,23 +75,43 @@ After a break
     }
 
     [Fact]
+    public void ValidDocxWithMediaRelativePathReturnsValidMarkdown()
+    {
+        var converter = new DocxToMarkdownProcessor("test_data/docconverter.docx", "../../");
+        var (result, media) = converter.Process();
+
+        // code files are saved using windows format.
+        // To ensure tests work on both environments, replace \r\n with environment new line 
+        var expected = EXPECTED_SAMPLE
+            .Replace("\r\n", Environment.NewLine)
+            .Replace("./image1.png", "../../image1.png");
+
+        var deterministicResult = GuidRegex().Replace(result, "image1.png");
+
+        Assert.NotNull(result);
+        Assert.NotNull(media);
+        Assert.NotNull(media);
+        Assert.Equal(expected, deterministicResult);
+    }
+
+    [Fact]
     public void NonExistingFileThrowsError()
     {
-        var converter = new DocxToMarkdownProcessor("test_data/invalid.docx");
+        var converter = new DocxToMarkdownProcessor("test_data/invalid.docx", ".");
         Assert.Throws<FileNotFoundException>(() => converter.Process());
     }
 
     [Fact]
     public void BadFileThrowsError()
     {
-        var converter = new DocxToMarkdownProcessor("test_data/badfile.docx");
+        var converter = new DocxToMarkdownProcessor("test_data/badfile.docx", ".");
         Assert.Throws<InvalidDataException>(() => converter.Process());
     }
     
     [Fact]
     public void WillMoveSpacesOutOfBold()
     {
-        var converter = new DocxToMarkdownProcessor("test_data/boldwithextraspace.docx");
+        var converter = new DocxToMarkdownProcessor("test_data/boldwithextraspace.docx", ".");
         var expected = $"**This is a bold string.** This is not.{Environment.NewLine}{Environment.NewLine}";
         var (result, _) = converter.Process();
         Assert.Equal(expected, result);


### PR DESCRIPTION
This pull request introduces several changes to the `documorph` project, primarily focusing on adding support for specifying a media output directory and ensuring that media files are correctly handled during the conversion process. The most important changes include adding a new command-line option for the media location, updating the conversion logic to use this new option, and modifying the relevant classes and tests to support and validate this new functionality.

### Command-line Interface Enhancements:

* [`src/documorph.cli/Program.cs`](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11R16-R34): Added a new option `--media-location` to specify the media output directory and updated the `Convert` method to handle this new option. [[1]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11R16-R34) [[2]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11L38-R49) [[3]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11L51-R95)

### Conversion Logic Updates:

* [`src/documorph.cli/Program.cs`](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11L92-R112): Updated the `ConvertFile` method to use the specified media output directory and adjusted the file paths accordingly.

### Model and Processor Adjustments:

* [`src/documorph/DocumentModel.cs`](diffhunk://#diff-3b35ab8cea0f0af5ac8a957cf700db96a2ed4f9cd49f61678f6d179681d41d6bL10-R10): Modified the `DocumentModel` class to accept a `mediaOutputRelativePath` parameter and updated the logic to use this path for media files. [[1]](diffhunk://#diff-3b35ab8cea0f0af5ac8a957cf700db96a2ed4f9cd49f61678f6d179681d41d6bL10-R10) [[2]](diffhunk://#diff-3b35ab8cea0f0af5ac8a957cf700db96a2ed4f9cd49f61678f6d179681d41d6bL29-R30)
* [`src/documorph/DocxToMarkdownProcessor.cs`](diffhunk://#diff-ae2cbe5d46dfc266b8d9a987988b105323681b46676d4fc8825c3b443949399dL11-R18): Updated the `DocxToMarkdownProcessor` constructor to accept a `mediaOutputRelativePath` and passed this parameter to the `DocumentModel`.

### Test Updates:

* [`test/documorph.tests/DocxToMarkdownTests.cs`](diffhunk://#diff-e99efa3120ab93293f9c4232bf450a374810dee3b51adcccb2081c10a8ba683dL49-R49): Added a new test to validate the conversion process with a relative media path and updated existing tests to include the new `mediaOutputRelativePath` parameter. [[1]](diffhunk://#diff-e99efa3120ab93293f9c4232bf450a374810dee3b51adcccb2081c10a8ba683dL49-R49) [[2]](diffhunk://#diff-e99efa3120ab93293f9c4232bf450a374810dee3b51adcccb2081c10a8ba683dL61-R61) [[3]](diffhunk://#diff-e99efa3120ab93293f9c4232bf450a374810dee3b51adcccb2081c10a8ba683dR77-R114)