### PR TITLE
Add support to output mediawiki files

### DIFF
--- a/src/documorph.cli/Program.cs
+++ b/src/documorph.cli/Program.cs
@@ -1,6 +1,7 @@
 var rootCommand = new RootCommand();
 var markdownCommand = new Command("md", "Converts a .docx file to markdown.");
 var asciidocCommand = new Command("asciidoc", "Converts a .docx file to asciidoc.");
+var wikiCommand = new Command("wiki", "Converts a .docx file to wikimedia format.");
 
 // Add option for source file or directory
 var sourceFileOption = new Option<FileInfo>(
@@ -22,6 +23,7 @@ var mediaLocationOption = new Option<DirectoryInfo>(
 
 rootCommand.AddCommand(markdownCommand);
 rootCommand.AddCommand(asciidocCommand);
+rootCommand.AddCommand(wikiCommand);
 
 markdownCommand.AddOption(sourceFileOption);
 markdownCommand.AddOption(targetFileOption);
@@ -31,10 +33,17 @@ asciidocCommand.AddOption(sourceFileOption);
 asciidocCommand.AddOption(targetFileOption);
 asciidocCommand.AddOption(mediaLocationOption);
 
+wikiCommand.AddOption(sourceFileOption);
+wikiCommand.AddOption(targetFileOption);
+wikiCommand.AddOption(mediaLocationOption);
+
 markdownCommand.SetHandler(ConvertMarkdown,
     sourceFileOption, targetFileOption, mediaLocationOption);
 
 asciidocCommand.SetHandler(ConvertAsciiDoc,
+    sourceFileOption, targetFileOption, mediaLocationOption);
+
+wikiCommand.SetHandler(ConvertWiki,
     sourceFileOption, targetFileOption, mediaLocationOption);
 
 return await rootCommand.InvokeAsync(args);
@@ -49,6 +58,12 @@ static async Task<int> ConvertAsciiDoc(FileInfo source, FileInfo target,
     DirectoryInfo? mediaLocation)
 {
     return await Convert(TargetType.AsciiDoc, source, target, mediaLocation);
+}
+
+static async Task<int> ConvertWiki(FileInfo source, FileInfo target,
+    DirectoryInfo? mediaLocation)
+{
+    return await Convert(TargetType.Wiki, source, target, mediaLocation);
 }
 
 static async Task<int> Convert(TargetType targetType, FileInfo source, FileInfo target,
@@ -95,6 +110,7 @@ static async Task<int> Convert(TargetType targetType, FileInfo source, FileInfo 
     {
         TargetType.Markdown => ".md",
         TargetType.AsciiDoc => ".asciidoc",
+        TargetType.Wiki => ".wiki",
         _ => throw new NotImplementedException(),
     };
 
@@ -124,6 +140,7 @@ static async Task ConvertFile(TargetType targetType, FileInfo fileToProcess, Fil
     {
         TargetType.Markdown => new DocxToMarkdownProcessor(fileToProcess.FullName, mediaOutputRelativePath),
         TargetType.AsciiDoc => new DocxToAsciiDocProcessor(fileToProcess.FullName, mediaOutputRelativePath),
+        TargetType.Wiki => new DocxToWikiProcessor(fileToProcess.FullName, mediaOutputRelativePath),
         _ => throw new InvalidOperationException("Invalid target type.")
     };
     // var processor = new DocxToMarkdownProcessor(fileToProcess.FullName, mediaOutputRelativePath);

--- a/src/documorph.cli/Utilities.cs
+++ b/src/documorph.cli/Utilities.cs
@@ -40,4 +40,4 @@ static partial class Utilities
     private static partial Regex TemplateRegex();
 }
 
-enum TargetType { Markdown, AsciiDoc }
+enum TargetType { Markdown, AsciiDoc, Wiki }

--- a/src/documorph/DocxToWikiProcessor.cs
+++ b/src/documorph/DocxToWikiProcessor.cs
@@ -114,7 +114,7 @@ public sealed class DocxToWikiProcessor(string inputFile, string mediaOutputRela
         foreach (var row in tableModel.Rows)
         {
             if (!isFirstRow)
-                builder.AppendLine("-");
+                builder.AppendLine("|-");
 
             foreach (var cell in row)
             {

--- a/src/documorph/DocxToWikiProcessor.cs
+++ b/src/documorph/DocxToWikiProcessor.cs
@@ -1,0 +1,195 @@
+using DocumentFormat.OpenXml.Linq;
+
+namespace documorph;
+
+/// <summary>
+/// Converts a .docx file to Wikimedia. The Docx file is opened in read-only mode with file share capabilities.
+/// </summary>
+/// <param name="inputFile">The .docx file to be converted</param>
+/// <param name="mediaOutputRelativePath">The relative path to the media output directory</param>
+/// <exception cref="FileNotFoundException">Thrown when the input file does not exist</exception>
+/// <exception cref="InvalidDataException">Thrown when the input file is not a valid .docx file</exception>
+public sealed class DocxToWikiProcessor(string inputFile, string mediaOutputRelativePath) : IDocxToTargetConverter
+{
+    /// <summary>
+    /// Processes the DOCX file and converts it to the AsciiDoc format.
+    /// </summary>
+    /// <returns>
+    /// A tuple containing the result as a string and an enumerable collection of <see cref="MediaModel"/> objects.
+    /// </returns>
+    public (string Result, IEnumerable<MediaModel> Media) Process()
+    {
+        using var wordPackage = Package.Open(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var wordDocument = WordprocessingDocument.Open(wordPackage);
+
+        var model = DocumentModel.FromDocument(wordDocument, mediaOutputRelativePath);
+        var result = new StringBuilder();
+
+        var children = model.Children.Select((x, i) => (Element: x, Index: i)).ToList();
+        foreach (var (element, index) in children)
+        {
+            switch (element)
+            {
+                case ParagraphModel paragraphModel:
+                    var nextParagraphModel = index < children.Count - 1 ? children[index + 1].Element as ParagraphModel : null;
+                    ProcessParagraph(paragraphModel, nextParagraphModel, false, result);
+                    break;
+                case TableModel tableModel:
+                    ProcessTable(tableModel, result);
+                    break;
+            }
+        }
+
+        return (result.ToString(), model.Media);
+    }
+
+    private void ProcessParagraph(ParagraphModel paragraphModel, ParagraphModel? nextParagraphModel, bool skipNewLine, StringBuilder builder)
+    {
+        if (paragraphModel.IsHeading)
+        {
+            builder.Append($"{new string('=', paragraphModel.HeadingLevel)} ");
+        }
+
+        if (paragraphModel.IsList)
+        {
+            var listMarker = paragraphModel.ListFormat switch
+            {
+                "decimal" => new string('#', paragraphModel.ListItemLevel + 1),
+                "bullet" => new string('*', paragraphModel.ListItemLevel + 1),
+                _ => ""
+            };
+            builder.Append($"{listMarker} ");
+        }
+
+        if (paragraphModel.IsQuote)
+        {
+            builder.Append($"<blockquote>");
+        }
+
+        var children = paragraphModel.Children.Select((x, i) => (Element: x, Index: i)).ToList();
+        foreach (var (element, index) in children)
+        {
+            switch (element)
+            {
+                case RunModel run:
+                    var previousRunModel = index > 0 ? children[index - 1].Element as RunModel : null;
+                    var nextRunModel = index < children.Count - 1 ? children[index + 1].Element as RunModel : null;
+                    ProcessRun(run, previousRunModel, nextRunModel, builder);
+                    break;
+                case HyperlinkModel hyperlink:
+                    ProcessHyperlink(hyperlink, builder);
+                    break;
+            }
+        }
+
+        if (paragraphModel.IsQuote)
+        {
+            builder.Append($"</blockquote>");
+        }
+
+        if (paragraphModel.IsHeading)
+        {
+            builder.Append($" {new string('=', paragraphModel.HeadingLevel)}");
+        }
+
+        if (!skipNewLine && !paragraphModel.IsEmpty)
+        {
+            builder.AppendLine();
+        }
+        if (!skipNewLine &&
+            (!paragraphModel.IsList || (!nextParagraphModel?.IsList ?? true)) &&
+            !paragraphModel.IsEmpty)
+        {
+            builder.AppendLine();
+        }
+    }
+
+    private void ProcessTable(TableModel tableModel, StringBuilder builder)
+    {
+        var isFirstRow = true;
+
+        var columns = tableModel.Rows.First().Select(x => "1");
+        builder.AppendLine("{|");
+
+        foreach (var row in tableModel.Rows)
+        {
+            if (!isFirstRow)
+                builder.AppendLine("-");
+
+            foreach (var cell in row)
+            {
+                builder.Append('|');
+
+                ProcessParagraph(cell, null, true, builder);
+                builder.AppendLine();
+            }
+
+            isFirstRow = false;
+        }
+        // builder.AppendLine();
+        builder.AppendLine("|}");
+    }
+
+    private void ProcessRun(RunModel runModel, RunModel? previousRunModel, RunModel? nextRunModel, StringBuilder builder)
+    {
+        if (runModel.IsBreak)
+        {
+            builder.AppendLine();
+            return;
+        }
+
+        var markdownSymbols = new Dictionary<Func<RunModel, RunModel?, bool>, (string Start, string End)>
+        {
+            { (rm, reference) => rm.IsBold && !(reference?.IsBold ?? false), ("'''", "'''") },
+            { (rm, reference) => rm.IsItalic && !(reference?.IsItalic ?? false), ("''", "''") },
+            { (rm, reference) => rm.IsStrike && !(reference?.IsStrike ?? false), ("<s>", "</s>") },
+            { (rm, reference) => rm.IsUnderline && !(reference?.IsUnderline ?? false), ("<u>", "</u>") }
+        };
+
+        if (runModel.IsImage)
+        {
+            builder.Append($"[[File:{runModel.Image?.FileName}|");
+        }
+
+        var text = runModel.IsText ? runModel.Text : runModel.Image?.Description;
+        text ??= string.Empty;
+
+        foreach (var symbol in markdownSymbols)
+        {
+            if (symbol.Key(runModel, previousRunModel))
+                builder.Append(symbol.Value.Start);
+        }
+
+        // move spaces at the end of text to a new string
+        var spaces = text.Reverse().TakeWhile(char.IsWhiteSpace).ToList();
+        builder.Append(text.TrimEnd(' '));
+
+        foreach (var symbol in markdownSymbols.Reverse())
+        {
+            if (symbol.Key(runModel, nextRunModel))
+                builder.Append(symbol.Value.End);
+        }
+
+        builder.Append(string.Join(string.Empty, spaces));
+
+        if (runModel.IsImage)
+        {
+            builder.Append("]]");
+        }
+    }
+
+    private void ProcessHyperlink(HyperlinkModel hyperlink, StringBuilder builder)
+    {
+        builder.Append($"[{hyperlink.Uri} ");
+
+        var children = hyperlink.Runs.Select((x, i) => (Element: x, Index: i)).ToList();
+        foreach (var (element, index) in children)
+        {
+            var previousRunModel = index > 0 ? children[index - 1].Element : null;
+            var nextRunModel = index < children.Count - 1 ? children[index + 1].Element : null;
+            ProcessRun(element, previousRunModel, nextRunModel, builder);
+        }
+
+        builder.Append("]");
+    }
+}

--- a/test/documorph.tests/DocxToWikiTests.cs
+++ b/test/documorph.tests/DocxToWikiTests.cs
@@ -1,0 +1,150 @@
+using System.Text.RegularExpressions;
+
+namespace documorph.tests;
+
+public partial class DocxToWikiTests
+{
+    private const string EXPECTED_SAMPLE = @"= Heading 1 =
+
+Some first paragraph. 
+
+'''Some bold'''.
+
+''Some italics''.
+
+[https://blog.lpains.net/ A link].
+
+== Heading 2 ==
+
+Another paragraph.
+
+=== Heading 3 ===
+
+* Bullet 1
+** Child Bullet 1.1
+*** Child Bullet 1.1.1
+* Bullet 2
+* Bullet 3
+
+==== Heading 4 ====
+
+# List 1
+## Child List 1.1
+### Child Bullet 1.1.1
+# List 2
+# List 3
+
+{|
+|Column 1
+|Column 2
+|Column 3
+|Column 4
+|Column 5
+-
+|Cel 1 1
+|Cell 2 1
+|Cell 3 1
+|Cell 4 1
+|Cell 5 1
+-
+|Cell 1 2
+|Cell 2 2 
+|Cell 3 2
+|Cell 4 2
+|Cell 5 2
+-
+|Cell 1 3
+|Cell 2 3
+|Cell 3 3
+|Cell 4 3
+|Cell 4 3
+|}
+<blockquote>This is a quote</blockquote>
+
+<blockquote>This is a quote2</blockquote>
+
+<blockquote>This is a quote3</blockquote>
+
+[[File:./image1.png|A screenshot of a computer  Description automatically generated]]
+
+
+
+
+After a break
+
+";
+
+    [Fact]
+    public void ValidDocxReturnsValidMarkdown()
+    {
+        var converter = new DocxToWikiProcessor("test_data/docconverter.docx", ".");
+        var (result, media) = converter.Process();
+
+        // code files are saved using windows format.
+        // To ensure tests work on both environments, replace \r\n with environment new line 
+        var expected = EXPECTED_SAMPLE
+            .Replace("\r\n", Environment.NewLine);
+
+        var deterministicResult = GuidRegex().Replace(result, "image1.png");
+
+        Assert.NotNull(result);
+        Assert.NotNull(media);
+        Assert.NotNull(media);
+        Assert.Equal(expected, deterministicResult);
+    }
+
+    [Fact]
+    public void ValidDocxWithMediaRelativePathReturnsValidMarkdown()
+    {
+        var converter = new DocxToWikiProcessor("test_data/docconverter.docx", "../../");
+        var (result, media) = converter.Process();
+
+        // code files are saved using windows format.
+        // To ensure tests work on both environments, replace \r\n with environment new line 
+        var expected = EXPECTED_SAMPLE
+            .Replace("\r\n", Environment.NewLine)
+            .Replace("./image1.png", "../../image1.png");
+
+        var deterministicResult = GuidRegex().Replace(result, "image1.png");
+
+        Assert.NotNull(result);
+        Assert.NotNull(media);
+        Assert.NotNull(media);
+        Assert.Equal(expected, deterministicResult);
+    }
+
+    [Fact]
+    public void NonExistingFileThrowsError()
+    {
+        var converter = new DocxToWikiProcessor("test_data/invalid.docx", ".");
+        Assert.Throws<FileNotFoundException>(() => converter.Process());
+    }
+
+    [Fact]
+    public void BadFileThrowsError()
+    {
+        var converter = new DocxToWikiProcessor("test_data/badfile.docx", ".");
+        Assert.Throws<InvalidDataException>(() => converter.Process());
+    }
+    
+    [Fact]
+    public void WillMoveSpacesOutOfBold()
+    {
+        var converter = new DocxToWikiProcessor("test_data/boldwithextraspace.docx", ".");
+        var expected = $"'''This is a bold string.''' This is not.{Environment.NewLine}{Environment.NewLine}";
+        var (result, _) = converter.Process();
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void WillCorrectlyHandleBoldAndItalics()
+    {
+        var converter = new DocxToWikiProcessor("test_data/boldanditalics.docx", ".");
+        var expected = $"'''''Bold and Italics'''''{Environment.NewLine}{Environment.NewLine}'''<u>Bold and Underline</u>'''{Environment.NewLine}{Environment.NewLine}";
+        var (result, _) = converter.Process();
+        Assert.Equal(expected, result);
+    }
+
+    [GeneratedRegex("([0-9A-Fa-f]{8}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{12}).png")]
+    private static partial Regex GuidRegex();
+}

--- a/test/documorph.tests/DocxToWikiTests.cs
+++ b/test/documorph.tests/DocxToWikiTests.cs
@@ -40,19 +40,19 @@ Another paragraph.
 |Column 3
 |Column 4
 |Column 5
--
+|-
 |Cel 1 1
 |Cell 2 1
 |Cell 3 1
 |Cell 4 1
 |Cell 5 1
--
+|-
 |Cell 1 2
 |Cell 2 2 
 |Cell 3 2
 |Cell 4 2
 |Cell 5 2
--
+|-
 |Cell 1 3
 |Cell 2 3
 |Cell 3 3

--- a/test/documorph.tests/ProgramWikiTests.cs
+++ b/test/documorph.tests/ProgramWikiTests.cs
@@ -1,0 +1,93 @@
+namespace documorph.tests;
+
+public class ProgramWikiTests
+{
+    [Fact]
+    public void MissingInReturn1()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--out", "test.wiki" }]);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void MissingOutReturn1()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "test.docx" }]);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void WillConvertSimpleDocx()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "./test_data/simpletest.docx", "--out", "./test_data/WillConvertSimpleDocx.wiki" }]);
+
+        Assert.Equal(0, result);
+        Assert.True(File.Exists("./test_data/WillConvertSimpleDocx.wiki"));
+    }
+    
+    [Fact]
+    public void ValidParameters()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "./test_data/docconverter.docx", "--out", "./test_data/Test_ValidParameters.wiki" }]);
+
+        Assert.Equal(0, result);
+        Assert.True(File.Exists("./test_data/Test_ValidParameters.wiki"));
+    }
+    
+    [Fact]
+    public void WillCreateOutputDirectoryIfNeeded()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "./test_data/docconverter.docx", "--out", "./test_data2/Test_ValidParameters.wiki" }]);
+
+        Assert.Equal(0, result);
+        Assert.True(File.Exists("./test_data2/Test_ValidParameters.wiki"));
+    }
+    
+    [Fact]
+    public void InvalidInFileParameters()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "test_data/docconverterbad.docx", "--out", "test_data/Test_ValidParameters.wiki" }]);
+
+        Assert.Equal(1, result);
+    }
+    
+    [Fact]
+    public void InvalidOutFileParameters()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "test_data/docconverter.docx", "--out", "" }]);
+
+        Assert.Equal(1, result);
+    }
+    
+    [Fact]
+    public void WillFailIfInputIsDirectoryAndOutputIsNotDirectory()
+    {
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "test_data/", "--out", "test_data/docconverter.docx" }]);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void WillConvertAnEntireFolder()
+    {
+        Directory.CreateDirectory("WillConvertAnEntireFolderwiki/");
+        File.Copy("test_data/docconverter.docx", "WillConvertAnEntireFolderwiki/docconverter1.docx", true);
+        File.Copy("test_data/docconverter.docx", "WillConvertAnEntireFolderwiki/docconverter2.docx", true);
+        var entryPoint = typeof(Program).Assembly.EntryPoint!;
+        var result = entryPoint.Invoke(null, [new string[] { "wiki", "--in", "WillConvertAnEntireFolderwiki/", "--out", "WillConvertAnEntireFolderwiki/" }]);
+
+        Assert.Equal(0, result);
+        Assert.Equal(Directory.GetFiles("WillConvertAnEntireFolderwiki/", "*.docx").Length, 
+            Directory.GetFiles("WillConvertAnEntireFolderwiki/", "*.wiki").Length);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to convert `.docx` files to Wikimedia format. The most important changes include adding a new command for Wikimedia conversion, implementing the conversion logic, and adding corresponding tests.

### New Feature: Wikimedia Conversion

* **Command Addition**:
  - Added `wikiCommand` to the list of commands in `Program.cs` (`src/documorph.cli/Program.cs`). [[1]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11R4) [[2]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11R26) [[3]](diffhunk://#diff-b047d5cf4baa6a78e7025ecbae2155c10d505447292ae6850ccce3abe171da11R36-R48)
  - Added handler `ConvertWiki` for the new `wikiCommand` (`src/documorph.cli/Program.cs`).
  - Updated `TargetType` enum to include `Wiki` (`src/documorph.cli/Utilities.cs`).

* **Conversion Logic**:
  - Implemented `DocxToWikiProcessor` class to handle the conversion of `.docx` files to Wikimedia format (`src/documorph/DocxToWikiProcessor.cs`).

### Tests

* **Unit Tests**:
  - Added tests for `DocxToWikiProcessor` to ensure correct conversion and error handling (`test/documorph.tests/DocxToWikiTests.cs`).
  
* **Integration Tests**:
  - Added integration tests for the new `wikiCommand` to ensure end-to-end functionality (`test/documorph.tests/ProgramWikiTests.cs`).

Closes #13 